### PR TITLE
Auth Token Key is hardcoded. Shouldn't this be using the one from config vars?

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,15 +5,11 @@ const app = express();
 const axios = require('axios');
 require('dotenv').config();
 
-app.get('/api/jwt/:key/:user', (req, res) => {
+app.get('/api/jwt/:user', (req, res) => {
   const { SERVER_URL, SERVER_KEY } = process.env;
 
-  if (req.params.key !== SERVER_KEY) {
-    res.sendStatus(403);
-  }
-
   axios.post(`${SERVER_URL}/api/jwt`, {
-    mobile_api_key: req.params.key,
+    mobile_api_key: SERVER_KEY,
     user_name: req.params.user
   })
   .then(function (jwtResponse) {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -24,9 +24,7 @@ class App extends Component {
 const auth = {
   isAuthenticated: false,
   authenticate(user, callback) {
-    const key = '6821c80f08b67a3f0dd23ec7563fb7d0ef306a6dcb58ea7760a5a4d8ae6525ce';
-
-    fetch(`/api/jwt/${key}/${user}`)
+    fetch(`/api/jwt/${user}`)
       .then(res => res.json())
       .then(
         (result) => {


### PR DESCRIPTION
When I deploy to Heroku and set the config vars, I get an error when I click the Login button. When viewing the console I see a 403 (Forbidden) error.

It seems like the app is not picking up my key from the config vars since there is one already hardcoded.
https://github.com/nexmo-community/contact-center-react/blob/f3371ac653c22acf2c2106398bf2119a4a7c8a6b/client/src/App.js#L27